### PR TITLE
Added destroy rate calls to clear up rate resources

### DIFF
--- a/flexbe_core/flexbe_core/core/ros_state_machine.py
+++ b/flexbe_core/flexbe_core/core/ros_state_machine.py
@@ -29,13 +29,16 @@ class RosStateMachine(StateMachine):
 
     def wait(self, seconds=None, condition=None):
         if seconds is not None and seconds > 0:
-            RosStateMachine._node.create_rate(1 / seconds, RosStateMachine._node.get_clock()).sleep()
+            rate = RosStateMachine._node.create_rate(1 / seconds, RosStateMachine._node.get_clock())
+            rate.sleep()
+            RosStateMachine._node.destroy_rate(rate)
         if condition is not None:
             rate = RosStateMachine._node.create_rate(100, RosStateMachine._node.get_clock())
             while rclpy.ok():
                 if condition():
                     break
                 rate.sleep()
+            RosStateMachine._node.destroy_rate(rate)
 
     def _enable_ros_control(self):
         self._is_controlled = True

--- a/flexbe_core/flexbe_core/proxy/proxy_publisher.py
+++ b/flexbe_core/flexbe_core/proxy/proxy_publisher.py
@@ -153,8 +153,9 @@ class ProxyPublisher(object):
 
         while (ProxyPublisher._node.get_clock().now() - starting_time).nanoseconds * 10 ** -9 < timeout:
             if pub.get_subscription_count() > 0:
+                ProxyPublisher._node.destroy_rate(rate)
                 return True
 
             rate.sleep()
-
+        ProxyPublisher._node.destroy_rate(rate)
         return False

--- a/flexbe_core/test/test_core.py
+++ b/flexbe_core/test/test_core.py
@@ -113,7 +113,7 @@ class TestCore(unittest.TestCase):
                 sub.remove_last_msg(topic)
                 raise AssertionError('Should not receive message on topic %s, but got:\n%s'
                                      % (topic, str(received)))
-
+        self.node.destroy_rate(rate)
     # Test Cases
     def test_event_state(self):
         rclpy.spin_once(self.node, executor=self.executor, timeout_sec=1)

--- a/flexbe_mirror/flexbe_mirror/flexbe_mirror.py
+++ b/flexbe_mirror/flexbe_mirror/flexbe_mirror.py
@@ -65,7 +65,7 @@ class FlexbeMirror(Node):
         rate = self.create_rate(10, self.get_clock())
         while self._stopping:
             rate.sleep()
-
+        self.destroy_rate(rate)
         if self._running:
             Logger.logwarn('Received a new mirror structure while mirror is already running, '
                            'adding to buffer (checksum: %s).' % str(msg.behavior_id))
@@ -105,7 +105,7 @@ class FlexbeMirror(Node):
             rate = self.create_rate(10, self.get_clock())
             while self._stopping:
                 rate.sleep()
-
+            self.destroy_rate(rate)
             if self._running:
                 Logger.logwarn('Tried to start mirror while it is already running, will ignore.')
                 return
@@ -157,6 +157,7 @@ class FlexbeMirror(Node):
                 rate = self.create_rate(10, self.get_clock())
                 while self._running:
                     rate.sleep()
+                self.destroy_rate(rate)
             else:
                 Logger.loginfo('No onboard behavior is active.')
 
@@ -240,6 +241,7 @@ class FlexbeMirror(Node):
                 rate = self.create_rate(100, self.get_clock())
                 while self._running:
                     rate.sleep()
+                self.destroy_rate(rate)
                 self._sm = None
             if msg.current_state_checksum in self._state_checksums:
                 current_state_path = self._state_checksums[msg.current_state_checksum]

--- a/flexbe_onboard/flexbe_onboard/flexbe_onboard.py
+++ b/flexbe_onboard/flexbe_onboard/flexbe_onboard.py
@@ -123,6 +123,7 @@ class FlexbeOnboard(Node):
                     if active_state is not None or not self._running:
                         break
                     rate.sleep()
+                self.destroy_rate(rate)
 
                 # extract the active state if any
                 if active_state is not None:

--- a/flexbe_onboard/test/test_onboard.py
+++ b/flexbe_onboard/test/test_onboard.py
@@ -37,6 +37,7 @@ class TestOnboard(unittest.TestCase):
 
     @classmethod
     def tearDown(self):
+        self.node.destroy_rate(self.rate)
         self.node.destroy_node()
         self.executor.shutdown()
         rclpy.shutdown(context=self.context)

--- a/flexbe_testing/flexbe_testing/test_context.py
+++ b/flexbe_testing/flexbe_testing/test_context.py
@@ -111,6 +111,7 @@ class LaunchContext(TestContext):
                 is_running = eval(self._wait_cond)
                 check_running_rate.sleep()
             Logger.print_positive('waiting condition satisfied')
+            self._node.destroy_rate(check_running_rate)
         except Exception as e:
             self._valid = False
             Logger.print_negative('unable to check waiting condition:\n\t%s' % str(e))
@@ -126,6 +127,7 @@ class LaunchContext(TestContext):
         self._node.get_logger().info("Waiting for all launched nodes to exit")
         while not all(name in self._exit_codes for name in self._launched_proc_names):
             check_exited_rate.sleep()
+        self._node.destroy_rate(check_exited_rate)
 
     def __exit__(self, exception_type, exception_value, traceback):
         self._launchrunner.stop()


### PR DESCRIPTION
After running the first behavior, I noticed the start_behavior node hogging a lot of the CPU resources, even after the behavior was stopped. 

In the wait loop inside ros_state_machine.py, I added a call to destroy_rate to free up the resources of rate on every loop callback. This fixed the heavy CPU usage. 

I added the destory_rate calls to all other cases of rate creation in the engine.  

Running ros2-devel flexbe behavior engine on Ubuntu 22 with ROS 2 Humble.
