### PR TITLE
Fixed bug when trying to get result state/GoalStatus.

### DIFF
--- a/flexbe_core/flexbe_core/proxy/proxy_action_client.py
+++ b/flexbe_core/flexbe_core/proxy/proxy_action_client.py
@@ -46,6 +46,7 @@ class ProxyActionClient:
     _cancel_current_goal = {}
 
     _result = {}
+    _result_status = {}
     _feedback = {}
 
     @staticmethod
@@ -68,6 +69,7 @@ class ProxyActionClient:
 
             print("Shutdown proxy action clients  ...")
             ProxyActionClient._result.clear()
+            ProxyActionClient._result_status.clear()
             ProxyActionClient._feedback.clear()
             ProxyActionClient._cancel_current_goal.clear()
             ProxyActionClient._has_active_goal.clear()
@@ -141,6 +143,7 @@ class ProxyActionClient:
             raise ValueError(f'Cannot send goal for action client {topic}: Topic not available.')
         # reset previous results
         ProxyActionClient._result[topic] = None
+        ProxyActionClient._result_status[topic] = None
         ProxyActionClient._feedback[topic] = None
         ProxyActionClient._cancel_current_goal[topic] = False
         ProxyActionClient._has_active_goal[topic] = True
@@ -181,7 +184,9 @@ class ProxyActionClient:
     @classmethod
     def _result_callback(cls, future, topic):
         result = future.result().result
+        result_status = future.result().status
         ProxyActionClient._result[topic] = result
+        ProxyActionClient._result_status[topic] = result_status
         ProxyActionClient._has_active_goal[topic] = False
 
     @classmethod
@@ -273,7 +278,7 @@ class ProxyActionClient:
         @type topic: string
         @param topic: The topic of interest.
         """
-        return ProxyActionClient._clients[topic].get_state()
+        return ProxyActionClient._result_status.get(topic)
 
     @classmethod
     def is_active(cls, topic):


### PR DESCRIPTION
Hi, 

this should fix the bug from Issue https://github.com/FlexBE/flexbe_behavior_engine/issues/3. 

It is now possible to use `ProxyActionClient.get_state("my_test_topic")` to query the result state/GoalStatus: 
```
if self._action_client.has_result(self._topic):
    result = self._action_client.get_result(self._topic)
    result_state = self._action_client.get_state(self._topic)
    Logger.loginfo(f'Got result from action server: {result=} ; {result_state=}')
```
Output: 
```
[start_behavior-4] [INFO] [1711467116.679000009] [behavior]: Got result from action server: result=nav2_msgs.action.NavigateToPose_Result(result=std_msgs.msg.Empty()) ; result_state=4
```
In this case `self._action_client.get_state(self._topic)` returned `4` which corresponds to `STATUS_SUCCEEDED` (see [action_msgs/msg/GoalStatus.msg](https://github.com/ros2/rcl_interfaces/blob/humble/action_msgs/msg/GoalStatus.msg)). 

PS: I am not sure whether the `humble` branch is the right one for this pull request, feel free to change the target branch if needed. 