### PR TITLE
Fix typo on rclpy logger call

### DIFF
--- a/flexbe_widget/flexbe_widget/behavior_action_server.py
+++ b/flexbe_widget/flexbe_widget/behavior_action_server.py
@@ -243,4 +243,4 @@ class BehaviorActionServer:
         self._current_state = msg.data
         if self._current_goal and self._current_goal.is_active:
             self._current_goal.publish_feedback(BehaviorExecution.Feedback(current_state=self._current_state))
-            self._node.get_logger().loginfo('Current state id = %d' % self._current_state)
+            self._node.get_logger().info('Current state id = %d' % self._current_state)


### PR DESCRIPTION
Use `info(...)` instead of `loginfo(...)` on rclpy logger on `behavior_action_server.py`. Otherwise an exception is raised and the result is never sent, leaving clients hanging.